### PR TITLE
Add PG17 meson build support

### DIFF
--- a/pldebugger.proj
+++ b/pldebugger.proj
@@ -3,6 +3,7 @@
 
     <Target Name="all" DependsOnTargets="plugin_debugger" />
 
+    <Import Project="settings.projinc" />
 
     <!-- Detect if we're running against community PostgreSQL, or
 	 EnterpriseDB's Advanced Server. When building against EDB, we include

--- a/pldebugger.proj
+++ b/pldebugger.proj
@@ -33,11 +33,18 @@
             </PropertyGroup>
         </When>
         <Otherwise>
-            <PropertyGroup>
-                <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
-                <XTRA_LDFLAGS>/defaultlib:$(PGPATH)\Release\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
-                <MESON_XTRA_LDFLAGS>/defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</MESON_XTRA_LDFLAGS>
-            </PropertyGroup>
+            <When Condition="Exists('$(PGPATH)\Release\$(postgres)\$(postgres).lib')">
+                <PropertyGroup>
+                    <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
+                    <XTRA_LDFLAGS>/defaultlib:$(PGPATH)\Release\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
+                </PropertyGroup>
+	    </When>
+            <Otherwise>
+	        <PropertyGroup>
+                    <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
+                    <XTRA_LDFLAGS>/defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</XTRA_LDFLAGS>
+                </PropertyGroup>
+	    </Otherwise>
         </Otherwise>
     </Choose>
 
@@ -62,7 +69,7 @@
         <CFLAGS>/nologo /wd4273 /TC /LD $(XTRA_CFLAGS) /D "WIN32" /D "__WIN32__" $(XTRA_ARCH_CFLAGS) /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_WINDLL" /D "_MBCS"</CFLAGS>
 
         <!-- Linker flags -->
-        <LDFLAGS>/DLL $(XTRA_LDFLAGS) $(MESON_XTRA_LDFLAGS) $(XTRA_ARCH_LDFLAGS) /defaultlib:user32 /defaultlib:netapi32 /defaultlib:advapi32 /defaultlib:shell32 /defaultlib:ws2_32 /defaultlib:Secur32.lib</LDFLAGS>
+        <LDFLAGS>/DLL $(XTRA_LDFLAGS) $(XTRA_ARCH_LDFLAGS) /defaultlib:user32 /defaultlib:netapi32 /defaultlib:advapi32 /defaultlib:shell32 /defaultlib:ws2_32 /defaultlib:Secur32.lib</LDFLAGS>
     </PropertyGroup>
 
     <ItemGroup>

--- a/pldebugger.proj
+++ b/pldebugger.proj
@@ -28,9 +28,13 @@
     <!-- Setup for Debug or Release -->
     <Choose>
         <When Condition="'$(DEBUG)'=='1'">
-            <PropertyGroup>
+            <PropertyGroup Condition="Exists('$(PGPATH)\Debug\$(postgres)\$(postgres).lib')">
                 <XTRA_CFLAGS>/Od /MDd /Zi /D "DEBUG=1" /D "_DEBUG"</XTRA_CFLAGS>
                 <XTRA_LDFLAGS>/DEBUG /defaultlib:$(PGPATH)\Debug\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
+            </PropertyGroup>
+            <PropertyGroup Condition="Exists('$(PGBUILDPATH)\src\backend\$(postgres).lib')">
+                <XTRA_CFLAGS>/Od /MDd /Zi /D "DEBUG=1" /D "_DEBUG"</XTRA_CFLAGS>
+                <XTRA_LDFLAGS>/DEBUG /defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</XTRA_LDFLAGS>
             </PropertyGroup>
         </When>
         <Otherwise>

--- a/pldebugger.proj
+++ b/pldebugger.proj
@@ -33,18 +33,14 @@
             </PropertyGroup>
         </When>
         <Otherwise>
-            <When Condition="Exists('$(PGPATH)\Release\$(postgres)\$(postgres).lib')">
-                <PropertyGroup>
-                    <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
-                    <XTRA_LDFLAGS>/defaultlib:$(PGPATH)\Release\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
-                </PropertyGroup>
-	    </When>
-            <Otherwise>
-	        <PropertyGroup>
-                    <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
-                    <XTRA_LDFLAGS>/defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</XTRA_LDFLAGS>
-                </PropertyGroup>
-	    </Otherwise>
+            <PropertyGroup Condition="Exists('$(PGPATH)\Release\$(postgres)\$(postgres).lib')">
+                <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
+                <XTRA_LDFLAGS>/defaultlib:$(PGPATH)\Release\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
+            </PropertyGroup>
+	    <PropertyGroup Condition="Exists('$(PGBUILDPATH)\src\backend\$(postgres).lib')">
+                <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
+                <XTRA_LDFLAGS>/defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</XTRA_LDFLAGS>
+            </PropertyGroup>
         </Otherwise>
     </Choose>
 

--- a/pldebugger.proj
+++ b/pldebugger.proj
@@ -3,7 +3,6 @@
 
     <Target Name="all" DependsOnTargets="plugin_debugger" />
 
-    <Import Project="settings.projinc" />
 
     <!-- Detect if we're running against community PostgreSQL, or
 	 EnterpriseDB's Advanced Server. When building against EDB, we include
@@ -37,6 +36,7 @@
             <PropertyGroup>
                 <XTRA_CFLAGS>/Ox /MD /GF</XTRA_CFLAGS>
                 <XTRA_LDFLAGS>/defaultlib:$(PGPATH)\Release\$(postgres)\$(postgres).lib</XTRA_LDFLAGS>
+                <MESON_XTRA_LDFLAGS>/defaultlib:$(PGBUILDPATH)\src\backend\$(postgres).lib</MESON_XTRA_LDFLAGS>
             </PropertyGroup>
         </Otherwise>
     </Choose>
@@ -62,11 +62,12 @@
         <CFLAGS>/nologo /wd4273 /TC /LD $(XTRA_CFLAGS) /D "WIN32" /D "__WIN32__" $(XTRA_ARCH_CFLAGS) /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_WINDLL" /D "_MBCS"</CFLAGS>
 
         <!-- Linker flags -->
-        <LDFLAGS>/DLL $(XTRA_LDFLAGS) $(XTRA_ARCH_LDFLAGS) /defaultlib:user32 /defaultlib:netapi32 /defaultlib:advapi32 /defaultlib:shell32 /defaultlib:ws2_32 /defaultlib:Secur32.lib</LDFLAGS>
+        <LDFLAGS>/DLL $(XTRA_LDFLAGS) $(MESON_XTRA_LDFLAGS) $(XTRA_ARCH_LDFLAGS) /defaultlib:user32 /defaultlib:netapi32 /defaultlib:advapi32 /defaultlib:shell32 /defaultlib:ws2_32 /defaultlib:Secur32.lib</LDFLAGS>
     </PropertyGroup>
 
     <ItemGroup>
         <IncludeDirs Include="/I$(PGPATH)\src\include" />
+        <IncludeDirs Include="/I$(PGBUILDPATH)\src\include" />
         <IncludeDirs Include="/I$(PGPATH)\src\include\port\win32" />
         <IncludeDirs Include="/I$(PGPATH)\src\include\port\win32_msvc" />
         <IncludeDirs Include="/I$(PGPATH)\src\port" />


### PR DESCRIPTION
The PostgreSQL 17 on Windows supports only Meson build system, where the build and source directories are separate. Therefore, some of the header files required are present in the source directory and some in the build directory.

Add a new variable PGBUILDPATH to define the build directory. Also, add a separate PropertyGroup to define the postgres.lib file path, as this file generated location is different in PG 17 compare with back branches.

Required build parameters are passed to msbuild, so updating settings.projinc is avoided.

Successfully test build the changes against PG17 and PG16 builds.